### PR TITLE
Use package-file directive in Cask

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,9 +1,6 @@
-(package "http.el" "0.0.1" "An HTTP client for Emacs.")
+(package-file "http.el")
 
 (source melpa)
-
-(depends-on "s")
-(depends-on "request")
 
 (development
  (depends-on "ert")


### PR DESCRIPTION
This helps you avoid repeating metadata between the `http.el` and `Cask` files.
